### PR TITLE
Fix local import for `go get`

### DIFF
--- a/gocollect.go
+++ b/gocollect.go
@@ -13,7 +13,7 @@ import (
     "strings"
     "time"
     getopt "github.com/kesselborn/go-getopt"
-    "./gocollector"
+    "github.com/ossobv/gocollect/gocollector"
 )
 
 // Initialized by -X ldflag. (Should be const, but is not allowed by the


### PR DESCRIPTION
While trying to `go get` this tool I got:

```
/home/luit/src/github.com/ossobv/gocollect/gocollect.go:16:5: local import "./gocollector" in non-local package
```

This fixes it.
