### PR TITLE
Bump to v0.9.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changes
 -------
 
+* v0.9.6 [2025-04-29]:
+
+  - os.pkg: Include packages that are on hold or maybe partially installed.
+    Without this change, held packages (apt-mark hold) would not be listed.
+  - sys.storage: Consider some drives only LOCKED if they set MBREnabled=Y.
+    This fixes so we aren't lied to that certain drives are locked, when they
+    in fact aren't.
+  - sys.storage: Fix bug when smartctl is not installed but nvme-cli is.
+
 * v0.9.5 [2025-02-19]:
 
   - core: Fix superfluous warnings in previous version.

--- a/gocollect-client/collectors/app.docker
+++ b/gocollect-client/collectors/app.docker
@@ -24,3 +24,11 @@ docker images --format='{{if not (eq .Tag "<none>")}}'\
 BEGIN{print "{\"images\":{"}
 /./{if(n)printf ",";print $0;n=1}
 END{print "}}"}'
+
+# Maybe add this to get versions? Only works for those images which do
+# org.opencontainers.image.version.
+#for image in $(docker images --format=\
+#'{{if not (eq .Tag "<none>")}}{{.Repository}}:{{.Tag}}{{end}}'); do
+#    docker inspect "$image" -f "{{index .RepoTags 0}} -\
+# {{index .Config.Labels \"org.opencontainers.image.version\"}}"
+#done

--- a/gocollect-client/collectors/os.pkg
+++ b/gocollect-client/collectors/os.pkg
@@ -21,7 +21,7 @@ while read x; do
 echo '{"installed":{'
 awk '
 BEGIN { RS = "\n\n" }
-/Status: (install|hold) ok installed/ {
+/Status: [^ ]* ok installed/ {
     arraylen = split($0, array, "\n")
     name = ""
     version = ""

--- a/gocollect-client/collectors/os.pkg
+++ b/gocollect-client/collectors/os.pkg
@@ -21,7 +21,7 @@ while read x; do
 echo '{"installed":{'
 awk '
 BEGIN { RS = "\n\n" }
-/Status: install ok installed/ {
+/Status: (install|hold) ok installed/ {
     arraylen = split($0, array, "\n")
     name = ""
     version = ""

--- a/gocollect-client/collectors/sys.storage
+++ b/gocollect-client/collectors/sys.storage
@@ -157,16 +157,58 @@ devices=$( (
 # ^- exclude Ceph "RADOS Block Device"
 
 if command -v sedutil-cli >/dev/null; then
-    sed_status() {
+    parse_sedutil_query() {
         local ret
-        if ret=$(sedutil-cli --query "$1" 2>/dev/null); then
+        ret=$1
+
+        # SAS ST10000NM0226 KT01 SEAGATE
+        # NVMe MTFDKCC30T7TGR G0MF000 312410498BB5
+        model=$(printf '%s' "$ret" | sed -ne '
+            /^./{s/[[:blank:]]\+/ /g;s/^[^ ]* //p;q}')
+        # 0x0100 Enterprise
+        # 0x0203 OPAL 2.0
+        mode=$(printf '%s' "$ret" | sed -ne '
+            s/^\(.*\) function (\(0x0100\|0x0203\)).*/\2 \1/p')
+        case "$mode $model" in
+        '0x0100 Enterprise '*|'0x0203 OPAL 2.0 NVMe MTF'*)
+            # So far, we've seen SEAGATE 10TB and 24TB with "Enterprise"
+            # SED that require MBREnabled=Y for locking to be on.
+            # [SAS ST10000NM0226 KT01 SEAGATE]
+            only_mbrenabled_means_locked=true
+            ;;
+        '0x0203 OPAL 2.0 NVMe MTF'*)
+            # Micron MTF* drives are the first/only NVMe/OPAL drives we've seen
+            # which require MBREnabled=Y to designate that they have locking
+            # enabled.
+            # [NVMe MTFDKCC30T7TGR G0MF000 312410498BB5]
+            only_mbrenabled_means_locked=true
+            ;;
+        *)
+            only_mbrenabled_means_locked=false
+            ;;
+        esac
+        if $only_mbrenabled_means_locked; then
+            ret=$(printf '%s' "$ret" | sed -ne "/^    Locked/{
+                s/.*LockingEnabled = Y, LockingSupported = Y,.*\
+ MBREnabled = Y,.*/LOCKED/p
+                s/.*LockingSupported = Y,.* MBREnabled = N.*/NOT_LOCKED/p
+                s/.*LockingSupported = N.*/NOT_SUPPORTED/p
+                q
+            }")
+        else
             ret=$(printf '%s' "$ret" | sed -ne '/^    Locked/{
                 s/.*LockingEnabled = Y, LockingSupported = Y.*/LOCKED/p
                 s/.*LockingEnabled = N, LockingSupported = Y.*/NOT_LOCKED/p
                 s/.*LockingSupported = N.*/NOT_SUPPORTED/p
                 q
             }')
-            echo "${ret:-UNEXPECTED}"
+        fi
+        echo "${ret:-UNEXPECTED}"
+    }
+    sed_status() {
+        local ret
+        if ret=$(sedutil-cli --query "$1" 2>/dev/null); then
+            parse_sedutil_query "$ret"
         else
             echo NOT_VALIDSED
         fi

--- a/gocollect-client/collectors/sys.storage
+++ b/gocollect-client/collectors/sys.storage
@@ -278,7 +278,7 @@ else
 "'"%s":"%s","%s":%s,"%s":%s}\n' \
             "$comma" logicalname "$dev" product "$product" \
             serial "$serial" size "$bytes" sectorsize "$sectorsize" \
-            sedstatus "$sedstatus"
+            sedstatus "$sedstatus" \
             has_boot $(is_in_list "$dev" $BOOTS) \
             has_rootfs $(is_in_list "$dev" $ROOTS)
     done

--- a/servers/Dockerfile
+++ b/servers/Dockerfile
@@ -21,5 +21,5 @@ RUN chmod -R ga-w /app /srv/gocollect-data
 USER www-data
 
 ENTRYPOINT ["python3"]
-CMD ["-c", "import os;print('\\x0a'.join(sorted(os.listdir('/app'))))"]
+CMD ["-c", "import os;print('\\x0a'.join(sorted(cmd for cmd in os.listdir('/app') if cmd != 'lib')))"]
 # run as: gocollect-consumer rmq2file|wsgi2file

--- a/servers/rmq2nb/service.py
+++ b/servers/rmq2nb/service.py
@@ -597,7 +597,7 @@ class Device(BaseResource):
     interface_url = '/api/dcim/interfaces/'
     interface_param = 'interface_id'
     interface_type = 'dcim.interface'
-    role_attr = 'device_role'
+    role_attr = 'role'
 
     @classmethod
     def set_defaults(cls, **kwargs):
@@ -618,7 +618,7 @@ class Device(BaseResource):
         site = prefix['site']['id'] if prefix and prefix['site'] else cls.site
         return {
             'name': data['fqdn'],
-            'device_role': cls.role,
+            'role': cls.role,
             'device_type': cls.type,
             'site': site,
             'custom_fields': {


### PR DESCRIPTION
* v0.9.6 [2025-04-29]:

  - os.pkg: Include packages that are on hold or maybe partially installed.    
    Without this change, held packages (apt-mark hold) would not be listed.    
  - sys.storage: Consider some drives only LOCKED if they set MBREnabled=Y.    
    This fixes so we aren't lied to that certain drives are locked, when they  
    in fact aren't.
  - sys.storage: Fix bug when smartctl is not installed but nvme-cli is.

